### PR TITLE
fix alignment of status tables

### DIFF
--- a/lib/nagiosharder.rb
+++ b/lib/nagiosharder.rb
@@ -397,7 +397,7 @@ class NagiosHarder
                          ).ago
                        end
           attempts = columns[5].inner_html if columns[5]
-          status_info = columns[6].inner_html.gsub('&nbsp;', '') if columns[6]
+          status_info = columns[6].inner_html.gsub('&nbsp;', '').gsub("\302\240", '') if columns[6]
 
           if host && service && status && last_check && duration && attempts && started_at && status_info
             service_extinfo_url = "#{extinfo_url}?type=2&host=#{host}&service=#{CGI.escape(service)}"


### PR DESCRIPTION
Nagios was injecting some weird characters at the end of status descriptions that were messing with terminal-table's alignment. This gives us clean right hand margins.
