### PR TITLE
Gender-neutrality but still slang essence

### DIFF
--- a/lib/nagiosharder/cli.rb
+++ b/lib/nagiosharder/cli.rb
@@ -156,7 +156,7 @@ class NagiosHarder
       if return_value
         0
       else
-        puts "Sorry, bro, nagios didn't like that."
+        puts "Sorry yo, nagios didn't like that."
         1
       end
     end


### PR DESCRIPTION
'Yo' is gaining popularity amongst youth as a gender-neutral term in many contexts. 

![](http://joethreat.files.wordpress.com/2012/02/yo_graphic2.jpg)
