### PR TITLE
Make sure we get all service status information, not only the first 100

### DIFF
--- a/lib/nagiosharder.rb
+++ b/lib/nagiosharder.rb
@@ -223,6 +223,7 @@ class NagiosHarder
         params['style'] = 'detail'
         params['embedded'] = '1'
         params['noheader'] = '1'
+        params['limit'] = 0
       else
         if options[:group]
           params['servicegroup'] = options[:group]
@@ -257,7 +258,7 @@ class NagiosHarder
         hostgroups[status[:group]] = status
       end
 
-     hostgroups 
+     hostgroups
     end
 
     def servicegroups_summary(options = {})
@@ -275,7 +276,7 @@ class NagiosHarder
     end
 
     def host_status(host)
-      host_status_url = "#{status_url}?host=#{host}&embedded=1&noheader=1"
+      host_status_url = "#{status_url}?host=#{host}&embedded=1&noheader=1&limit=0"
       response =  get(host_status_url)
 
       raise "wtf #{host_status_url}? #{response.code}" unless response.code == 200


### PR DESCRIPTION
As explained in #11, default limit for the number of services returned on the status page is 100. We need to explicitly specify limit=0 to get all services.
