### PR TITLE
Fix for date/time format following nagios3 documentation

### DIFF
--- a/lib/nagiosharder.rb
+++ b/lib/nagiosharder.rb
@@ -34,15 +34,20 @@ class NagiosHarder
       @version = version
       debug_output if ENV['DEBUG']
       basic_auth(@user, @password) if @user && @password
-      @nagios_time_format = if nagios_time_format == 'us'
-         "%m-%d-%Y %H:%M:%S"
-      else
-        if @version.to_i < 3
-          "%m-%d-%Y %H:%M:%S"
-        else
-          "%Y-%m-%d %H:%M:%S"
-        end
-      end
+      @nagios_time_format = case nagios_time_format
+                            when 'us'
+                              "%m-%d-%Y %H:%M:%S"
+                            when 'euro'
+                              "%d-%m-%Y %H:%M:%S"
+                            when 'iso8601'
+                              "%Y-%m-%d %H:%M:%S"
+                            else
+                              if @version.to_i < 3
+                                "%m-%d-%Y %H:%M:%S"
+                              else
+                                "%Y-%m-%dT%H:%M:%S"
+                              end
+                            end
       self
     end
 


### PR DESCRIPTION
Hi I just made a small change following nagios3 docs:

```
   us              (MM-DD-YYYY HH:MM:SS)
   euro            (DD-MM-YYYY HH:MM:SS)
   iso8601         (YYYY-MM-DD HH:MM:SS)
   strict-iso8601  (YYYY-MM-DDTHH:MM:SS)
```

if none of us|euro|iso8601 is passed when calling new it defaults to strict-iso8601 (for version >= 3).

Cheers!
